### PR TITLE
fix/: Fix broken navigation link

### DIFF
--- a/frontend/src/sections/Footer/Footer.tsx
+++ b/frontend/src/sections/Footer/Footer.tsx
@@ -33,7 +33,7 @@ const Footer: React.FC = () => {
             </li>
             <li>
               <a
-                href='/ContactUs'
+                href='/contactUs'
                 className='inline-block py-2 px-3 text-white no-underline'
               >
                 Contact Us

--- a/frontend/src/sections/Footer/Footer.tsx
+++ b/frontend/src/sections/Footer/Footer.tsx
@@ -33,7 +33,7 @@ const Footer: React.FC = () => {
             </li>
             <li>
               <a
-                href='/Contactus'
+                href='/ContactUs'
                 className='inline-block py-2 px-3 text-white no-underline'
               >
                 Contact Us


### PR DESCRIPTION
# Closes #69

I replaced the broken "Contact Us" link in the footer with the correct one.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- The footer navigation URL has been updated

### Type of change
- [x] Bug fix
- [ ] Feature update
- [ ] Breaking change
- [ ] Documentation update

### Demo
<!--- Provide an easily accessible demonstration of the changes, if applicable (preferably in png/gif format) -->

![image](https://github.com/user-attachments/assets/d6ba0855-5078-4192-9fd8-3e3c05c5da69)


### How has this been tested?
<!---[Describe the tests that you ran to verify your changes]-->
- via visiting the link in the footer section 


### Author Checklist
- [ ] Code has been commented, particularly in hard-to-understand areas 
- [x] Changes generate no new warnings
- [ ] Vital changes have been captured in unit and/or integration tests
- [ ] New and existing unit tests pass locally with my changes
- [ ] Documentation has been extended, if necessary
- [x] Merging to `main` from `fork:branchname`
