### PR TITLE
Linked Django india linkedIn page with Learn More button

### DIFF
--- a/frontend/src/sections/WhatIsDjango/WhatIsDjango.tsx
+++ b/frontend/src/sections/WhatIsDjango/WhatIsDjango.tsx
@@ -6,6 +6,9 @@ import useWidth from '@/hooks/useWidth'
 
 const WhatIsDjango = () => {
   const width = useWidth()
+  const handleClick = () => {
+    window.open("https://www.linkedin.com/company/djangoindia/")
+  };
   return (
     <section className='w-full h-auto relative bg-[#f9f4ee]'>
       <section className="w-full h-[600px] relative bg-[url('/whatIsDjango/Curve.svg')] bg-cover bg-no-repeat">
@@ -43,7 +46,7 @@ const WhatIsDjango = () => {
               contribute to the growth of the Django ecosystem in India.
               </p>
               <div className='z-20 pl-8'>
-                <Button>Learn More</Button>
+                <Button onClick={handleClick}>Learn More</Button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
# Closes #136
This PR links the Django India LinkedIn page to the "Learn More" button to provide more information about the community.

### Changes
- Linked the "Learn More" button to the official Django India LinkedIn page.
- Updated the frontend logic to handle the external link opening in a new tab.

### Type of change
- [x] Bug fix

### Flags
- Ensure proper handling of external links across different browsers.
- Verify if other sections also need external links for consistency.

### Demo
- Clicking the "Learn More" button redirects to the Django India LinkedIn page in a new tab.
  
### How has this been tested?
- Verified that the button opens the LinkedIn page on click.
- Tested across different browsers to ensure proper redirection.
  
### Author Checklist
- [x] Code has been commented, particularly in hard-to-understand areas 
- [x] Changes generate no new warnings
- [x] Merging to `main` from `fork:main`
