### PR TITLE
Fixed #136 -- [BUG] Learn More is not working

### DIFF
--- a/frontend/src/containers/LearnMoreDialog/LearnMoreDialog.tsx
+++ b/frontend/src/containers/LearnMoreDialog/LearnMoreDialog.tsx
@@ -1,0 +1,87 @@
+import {
+    Button,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components'
+import { DialogTriggerProps } from '@radix-ui/react-dialog'
+import React from 'react'
+
+const LearnMoreDialog = ({
+    onClose,
+}: {
+    onClose?: DialogTriggerProps['onClick']
+}) => {
+    return (
+    <Dialog>
+
+        <DialogTrigger asChild onClick={onClose}>
+        <Button className='text-xs md:text-base'>Learn More</Button>
+        </DialogTrigger>
+
+        <DialogContent className='sm:max-w-[730px]'>
+
+        <DialogHeader>
+            <DialogTitle className='text-2xl'>More on Django India</DialogTitle>
+            <DialogDescription>
+            For the Community by the Community
+            </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+            <div>
+                <h6 className='font-bold text-base inline-flex items-center gap-2'>
+                Exclusive Project Updates
+                </h6>
+                <p className='text-sm'>
+                Dive deep into the most exciting Django projects happening around!
+                Stay informed about initiatives, cutting-edge features, and key updates.
+                Discover how you can get involved, contribute your skills,
+                and be part of building something remarkable with the Django community.
+                </p>
+            </div>
+            <div>
+                <h6 className='font-bold text-base inline-flex items-center gap-2'>
+                Newsletters
+                </h6>
+                <p className='text-sm'>
+                Never miss an update on the latest trends, tools, and features
+                in the Django ecosystem. Our newsletters keep you informed about
+                what is happening in the Django world.whether it’s a major release,
+                noteworthy developments in India,
+                or international innovations shaping the future of web development.
+                </p>
+            </div>
+            <div>
+                <h6 className='font-bold text-base inline-flex items-center gap-2'>
+                Community Events
+                </h6>
+                <p className='text-sm'>
+                Join a vibrant community of Django developers through our meetups, webinars, and virtual hangouts.
+                Learn from experts, share your experiences, and connect with like-minded enthusiasts
+                across India and beyond. Be the first to hear about our upcoming events,
+                where you can network, learn, and grow your Django skills.
+                </p>
+            </div>
+            <div>
+                <h6 className='font-bold text-base inline-flex items-center gap-2'>
+                Spotlight on Contributions
+                </h6>
+                <p className='text-sm'>
+                Celebrate the amazing work being done by Indian developers in the Django community!
+                We’ll regularly highlight contributions that are making an impact,
+                offering inspiration and recognition to developers pushing boundaries.
+                Who knows, your next pull request might be the one that gets featured!
+                </p>
+            </div>
+        </div>
+
+        </DialogContent>
+    </Dialog>
+    )
+}
+
+export default LearnMoreDialog

--- a/frontend/src/containers/LearnMoreDialog/LearnMoreDialog.tsx
+++ b/frontend/src/containers/LearnMoreDialog/LearnMoreDialog.tsx
@@ -17,20 +17,16 @@ const LearnMoreDialog = ({
 }) => {
     return (
     <Dialog>
-
         <DialogTrigger asChild onClick={onClose}>
         <Button className='text-xs md:text-base'>Learn More</Button>
         </DialogTrigger>
-
         <DialogContent className='sm:max-w-[730px] max-h-[90vh] overflow-y-auto'>
-
         <DialogHeader>
             <DialogTitle className='text-2xl'>About Django India</DialogTitle>
             <DialogDescription>
             For the Community, by the Community
             </DialogDescription>
         </DialogHeader>
-
         <div className="grid gap-4 py-4">
             <div>
                 <p className='text-sm'>
@@ -190,7 +186,6 @@ const LearnMoreDialog = ({
                 </p>
             </div>
         </div>
-
         </DialogContent>
     </Dialog>
     )

--- a/frontend/src/containers/LearnMoreDialog/LearnMoreDialog.tsx
+++ b/frontend/src/containers/LearnMoreDialog/LearnMoreDialog.tsx
@@ -22,59 +22,171 @@ const LearnMoreDialog = ({
         <Button className='text-xs md:text-base'>Learn More</Button>
         </DialogTrigger>
 
-        <DialogContent className='sm:max-w-[730px]'>
+        <DialogContent className='sm:max-w-[730px] max-h-[90vh] overflow-y-auto'>
 
         <DialogHeader>
-            <DialogTitle className='text-2xl'>More on Django India</DialogTitle>
+            <DialogTitle className='text-2xl'>About Django India</DialogTitle>
             <DialogDescription>
-            For the Community by the Community
+            For the Community, by the Community
             </DialogDescription>
         </DialogHeader>
 
         <div className="grid gap-4 py-4">
             <div>
-                <h6 className='font-bold text-base inline-flex items-center gap-2'>
-                Exclusive Project Updates
+                <p className='text-sm'>
+                    Django India is a vibrant and rapidly growing community dedicated to uniting developers,
+                    enthusiasts, and technology professionals who share a deep passion for the Django framework.
+                    Our community serves as a hub for individuals across the country who are excited to collaborate,
+                    learn, and innovate together, no matter their experience level. Whether you&#39;re just starting
+                    your journey into web development or are a seasoned professional, Django India is the perfect
+                    place to connect with like-minded individuals and contribute to something larger.<br/><br/>
+
+                    At the heart of Django India lies a strong commitment to fostering an inclusive and open environment.
+                    We aim to make the Django ecosystem accessible to everyone by organizing a range of activities, from
+                    technical meetups and hands-on workshops to online discussions and knowledge-sharing sessions. These
+                    events are designed to not only help members build their technical skills but also to create a space
+                    where lasting professional relationships can form. By providing both educational resources and
+                    networking opportunities, we strive to be a key driver in the growth and success of Django within India.
+                </p>
+            </div>
+            <h6 className='font-bold text-base inline-flex items-center gap-2 text-xl'>
+                Our Community&#39;s Core Values:
+            </h6>
+            <div>
+            <h6 className='font-bold '>
+                Inclusivity:
                 </h6>
                 <p className='text-sm'>
-                Dive deep into the most exciting Django projects happening around!
-                Stay informed about initiatives, cutting-edge features, and key updates.
-                Discover how you can get involved, contribute your skills,
-                and be part of building something remarkable with the Django community.
+                    At Django India, we are deeply committed to ensuring that the community is open,
+                    welcoming, and inclusive to all. We believe that diversity is key to fostering innovation,
+                    and we actively encourage participation from individuals of all backgrounds—regardless of
+                    gender, ethnicity, location, or experience level. Everyone is welcome, from students and
+                    hobbyists to seasoned developers and tech professionals. We aim to make Django accessible
+                    to all by creating a space where every member can contribute meaningfully, learn from each
+                    other, and feel a sense of belonging.
                 </p>
             </div>
             <div>
                 <h6 className='font-bold text-base inline-flex items-center gap-2'>
-                Newsletters
+                Collaboration:
                 </h6>
                 <p className='text-sm'>
-                Never miss an update on the latest trends, tools, and features
-                in the Django ecosystem. Our newsletters keep you informed about
-                what is happening in the Django world.whether it’s a major release,
-                noteworthy developments in India,
-                or international innovations shaping the future of web development.
+                    We believe that the best way to grow as developers and professionals is by working together.
+                    Our community emphasizes collaboration on open-source projects, joint learning initiatives,
+                    and peer mentorship. Everyone has something valuable to contribute, and we encourage an
+                    environment where members help one another to solve complex problems and build exciting projects.
                 </p>
             </div>
             <div>
                 <h6 className='font-bold text-base inline-flex items-center gap-2'>
-                Community Events
+                Learning and Growth:
                 </h6>
                 <p className='text-sm'>
-                Join a vibrant community of Django developers through our meetups, webinars, and virtual hangouts.
-                Learn from experts, share your experiences, and connect with like-minded enthusiasts
-                across India and beyond. Be the first to hear about our upcoming events,
-                where you can network, learn, and grow your Django skills.
+                    One of the key missions of Django India is to facilitate continuous learning.
+                    We regularly host workshops, talks, and code-along sessions that cover a wide
+                    range of topics within Django and beyond. Members are encouraged to stay up-to-date
+                    with the latest developments in web technologies, share their knowledge, and apply
+                    new skills in real-world scenarios.
                 </p>
             </div>
             <div>
                 <h6 className='font-bold text-base inline-flex items-center gap-2'>
-                Spotlight on Contributions
+                Innovation:
                 </h6>
                 <p className='text-sm'>
-                Celebrate the amazing work being done by Indian developers in the Django community!
-                We’ll regularly highlight contributions that are making an impact,
-                offering inspiration and recognition to developers pushing boundaries.
-                Who knows, your next pull request might be the one that gets featured!
+                    At Django India, we don&#39;t just follow trends—we aim to set them. Our community is
+                    constantly pushing the boundaries of what&#39;s possible with Django, experimenting
+                    with new features, tools, and technologies. We encourage our members to take part
+                    in cutting-edge projects, contribute to open-source development, and come up with
+                    innovative solutions that can benefit the broader tech landscape.
+                </p>
+            </div>
+            <div>
+                <h6 className='font-bold text-base inline-flex items-center gap-2'>
+                No-Code Contributions:
+                </h6>
+                <p className='text-sm'>
+                    We understand that contributions to the Django community go beyond just writing code.
+                    That&#39;s why we actively promote no-code contributions, allowing non-technical members
+                    to play a vital role in the growth of the community. Whether it&#39;s through content creation,
+                    event organizing, design, documentation, or social media advocacy, everyone can contribute
+                    and make an impact. Django India embraces the philosophy that contributions come in many forms,
+                    and all are equally valuable to the success of our community.
+                </p>
+            </div>
+            <h6 className='font-bold text-base inline-flex items-center gap-2 text-xl'>
+                What Django India Offers:
+            </h6>
+            <div>
+                <h6 className='font-bold text-base inline-flex items-center gap-2'>
+                Meetups and Networking:
+                </h6>
+                <p className='text-sm'>
+                    Django India regularly hosts meetups, both online and in-person, where members can connect,
+                    share ideas, and collaborate. These events offer a chance to hear from expert speakers,
+                    participate in lively discussions, and engage with the local developer community. Our in-person
+                    meetups are held in various cities, offering a more localized and hands-on experience, while
+                    online events help us reach members no matter where they&#39;re located.
+                </p>
+            </div>
+            <div>
+                <h6 className='font-bold text-base inline-flex items-center gap-2'>
+                Workshops and Skill Development:
+                </h6>
+                <p className='text-sm'>
+                    Whether you&#39;re a beginner looking to understand the basics of Django or an advanced developer
+                    aiming to dive deeper into specialized topics, Django India&#39;s workshops cater to all. These
+                    workshops are led by experts who guide participants through various aspects of Django development,
+                    providing real-world examples and practical insights that can be applied to your projects.
+                </p>
+            </div>
+            <div>
+                <h6 className='font-bold text-base inline-flex items-center gap-2'>
+                Open-Source Contributions:
+                </h6>
+                <p className='text-sm'>
+                    Contributing to open-source software is a cornerstone of our community. Django India provides
+                    a platform for members to engage in open-source projects, enabling them to collaborate on
+                    meaningful contributions, code or no-code to the Django ecosystem. We encourage our members
+                    to get involved, not only to improve their own skills but also to give back to the global
+                    Django community.
+                </p>
+            </div>
+            <div>
+                <h6 className='font-bold text-base inline-flex items-center gap-2'>
+                Mentorship and Peer Support:
+                </h6>
+                <p className='text-sm'>
+                    Growth in a community thrives on mentorship and support. At Django India, we actively promote a
+                    culture of mentoring, where more experienced members are available to guide newcomers. This
+                    ensures that everyone, regardless of where they are in their learning journey, has access to
+                    the help they need to succeed.
+                </p>
+            </div>
+            <div>
+                <h6 className='font-bold text-base inline-flex items-center gap-2'>
+                Continuous Learning:
+                </h6>
+                <p className='text-sm'>
+                    We believe in lifelong learning and regularly share resources like tutorials, blogs, and code
+                    repositories to keep our members at the forefront of Django and web development. Our community
+                    fosters curiosity and encourages members to explore new frameworks, tools, and libraries that
+                    complement Django.
+                </p>
+            </div>
+            <div>
+                <h6 className='font-bold text-base inline-flex items-center gap-2 text-xl'>
+                Join the Movement:
+                </h6>
+                <p className='text-sm'>
+                    Django India is more than just a community; it&#39;s a movement aimed at growing the Django ecosystem
+                    in India and beyond. As we continue to expand, our focus remains on building a supportive,
+                    innovative, and collaborative environment for developers of all levels. We encourage our members
+                    to take part in everything we have to offer—whether it&#39;s by attending meetups, participating in
+                    workshops, contributing to projects, or mentoring the next generation of Django developers.<br/><br/>
+                    By becoming a member of Django India, you&#39;re joining a group of passionate individuals who are
+                    excited about learning and building the future of web development together. We&#39;re proud of the
+                    work we&#39;ve done so far, and we look forward to seeing how our community continues to evolve as we grow.
                 </p>
             </div>
         </div>

--- a/frontend/src/containers/LearnMoreDialog/index.ts
+++ b/frontend/src/containers/LearnMoreDialog/index.ts
@@ -1,0 +1,1 @@
+export { default as LearnMoreDialog } from './LearnMoreDialog'

--- a/frontend/src/containers/index.ts
+++ b/frontend/src/containers/index.ts
@@ -1,3 +1,4 @@
 export * from './SupportUsDialog'
 export * from './Event'
 export * from './ContactUs'
+export * from './LearnMoreDialog'

--- a/frontend/src/sections/WhatIsDjango/WhatIsDjango.tsx
+++ b/frontend/src/sections/WhatIsDjango/WhatIsDjango.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import Image from 'next/image'
-import { Button, DataCard } from '@components'
+import { DataCard } from '@components'
 import useWidth from '@/hooks/useWidth'
+import { LearnMoreDialog } from '@/containers/LearnMoreDialog'
 
 
 const WhatIsDjango = () => {
@@ -38,13 +39,13 @@ const WhatIsDjango = () => {
                 </div>
               </div>
               <p className='w-full md:max-w-[600px] text-sm  md:text-2xl pl-8  text-black font-medium'>
-              A vibrant community of Django developers, primarily from India. 
-              It unites passionate individuals who are eager to learn, share knowledge, and collaborate 
-              on innovative projects. Through our meetups, workshops, and online events, members actively 
+              A vibrant community of Django developers, primarily from India.
+              It unites passionate individuals who are eager to learn, share knowledge, and collaborate
+              on innovative projects. Through our meetups, workshops, and online events, members actively
               contribute to the growth of the Django ecosystem in India.
               </p>
               <div className='z-20 pl-8'>
-                <Button>Learn More</Button>
+                <LearnMoreDialog/>
               </div>
             </div>
           </div>

--- a/frontend/src/sections/WhatIsDjango/WhatIsDjango.tsx
+++ b/frontend/src/sections/WhatIsDjango/WhatIsDjango.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image'
 import { DataCard } from '@components'
 import useWidth from '@/hooks/useWidth'
-import { LearnMoreDialog } from '@/containers/LearnMoreDialog'
+import { LearnMoreDialog } from '@containers'
 
 
 const WhatIsDjango = () => {


### PR DESCRIPTION
Implemented functionality for the 'Learn More' button to open a dialog box when the 'Learn More' button is clicked. The dialog displays relevant content, improving user interaction and addressing the bug where the button previously had no action.


# Closes #136
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- added `/container/LearnMoreDialog/LearnMoreDialog.tsx` - this is the component which is shown when we click on button
- used `LearnMoreDialog` Component in `/sections/WhatIsDjango`

### Type of change
- [x] Bug fix
- [ ] Feature update
- [ ] Breaking change
- [ ] Documentation update

### Flags
No known issues

### Demo
![chrome_gZutabQkZK](https://github.com/user-attachments/assets/93f01838-7227-40cf-881c-9e04d4fedddf)

### How has this been tested?
- manual testing

### Author Checklist
- [ ] Code has been commented, particularly in hard-to-understand areas 
- [x] Changes generate no new warnings
- [ ] Vital changes have been captured in unit and/or integration tests
- [ ] New and existing unit tests pass locally with my changes
- [ ] Documentation has been extended, if necessary
- [x] Merging to `main` from `fork:issue_136`
