### PR TITLE
Fixed #212 - Prevent partners in past events

### DIFF
--- a/backend/djangoindia/api/views/event.py
+++ b/backend/djangoindia/api/views/event.py
@@ -1,51 +1,53 @@
-from djangoindia.api.serializers.event import (
-    EventRegistrationSerializer,
-    EventSerializer,
-    EventLiteSerializer,
-)
-from djangoindia.bg_tasks.event_registration import registration_confirmation_email_task
-from djangoindia.db.models import Event, EventRegistration,Volunteer, Sponsorship,CommunityPartner
-from rest_framework import generics, status, viewsets
-from rest_framework.mixins import CreateModelMixin, ListModelMixin, RetrieveModelMixin
-from rest_framework.response import Response
-
-from djangoindia.constants import POST, PRIMARY_KEY_SHORT
 from django.db.models import Prefetch
 from django.utils import timezone
+from djangoindia.api.serializers.event import (
+    EventLiteSerializer,
+    EventRegistrationSerializer,
+    EventSerializer,
+)
+from djangoindia.bg_tasks.event_registration import registration_confirmation_email_task
+from djangoindia.constants import POST
+from djangoindia.db.models import (
+    CommunityPartner,
+    Event,
+    EventRegistration,
+    Sponsorship,
+    Volunteer,
+)
+from rest_framework import status, viewsets
+from rest_framework.response import Response
+
 
 # Create your views here.
-class EventAPIView(
-    viewsets.ModelViewSet
-):
+class EventAPIView(viewsets.ModelViewSet):
     lookup_field = "slug"
-    queryset = Event.objects.all().prefetch_related(
-        Prefetch(
-            'sponsors',
-            queryset=Sponsorship.objects.filter(
-                type='event_sponsorship'
-            ).select_related('sponsor_details').only(
-                'tier',
-                'type',
-                'sponsor_details__url',
-                'sponsor_details__name',
-                'sponsor_details__type',
-                'sponsor_details__logo'
+    queryset = (
+        Event.objects.all()
+        .prefetch_related(
+            Prefetch(
+                "sponsors",
+                queryset=Sponsorship.objects.filter(type="event_sponsorship")
+                .select_related("sponsor_details")
+                .only(
+                    "tier",
+                    "type",
+                    "sponsor_details__url",
+                    "sponsor_details__name",
+                    "sponsor_details__type",
+                    "sponsor_details__logo",
+                ),
+                to_attr="event_sponsors",
             ),
-            to_attr='event_sponsors'
-        ),
-        Prefetch(
-            'volunteers',
-            queryset=Volunteer.objects.only(
-                'name',
-                'photo',
-                'about',
-                'email',
-                'twitter',
-                'linkedin'
+            Prefetch(
+                "volunteers",
+                queryset=Volunteer.objects.only(
+                    "name", "photo", "about", "email", "twitter", "linkedin"
+                ),
+                to_attr="event_volunteers",
             ),
-            to_attr='event_volunteers'
         )
-    ).order_by("-created_at")
+        .order_by("-created_at")
+    )
 
     def get_serializer_class(self):
         if self.request.method == POST:
@@ -55,37 +57,54 @@ class EventAPIView(
     def list(self, request, *args, **kwargs):
         queryset = self.get_queryset()
         all_community_partners = CommunityPartner.objects.all()
-        serializer = self.get_serializer(queryset, many=True, context={'all_community_partners': all_community_partners})
+        serializer = self.get_serializer(
+            queryset,
+            many=True,
+            context={"all_community_partners": all_community_partners},
+        )
         return Response(serializer.data)
 
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()
-        all_community_partners = CommunityPartner.objects.all()
-        serializer = EventSerializer(instance, context={'all_community_partners': all_community_partners})
+        # Only fetch partners who were created before the event
+        all_community_partners = CommunityPartner.objects.filter(
+            created_at__lte=instance.created_at
+        )
+        serializer = EventSerializer(
+            instance, context={"all_community_partners": all_community_partners}
+        )
         return Response(serializer.data)
 
     def post(self, request, *args, **kwargs):
         try:
             event_id = request.data.get("event")
             email = request.data.get("email")
-            
+
             event = self.get_event(event_id)
             self._validate_event_registration(event)
             self._check_existing_registration(email, event_id)
-            
+
             self.create(request, *args, **kwargs)
             self._send_confirmation_email(email, event_id)
-            
+
             return Response(
-                {"message": "You're in! We've sent a shiny email to your inbox. Time to celebrate!"},
-                status=status.HTTP_201_CREATED
+                {
+                    "message": (
+                        "You're in! We've sent a shiny email to your inbox. "
+                        "Time to celebrate!"
+                    )
+                },
+                status=status.HTTP_201_CREATED,
             )
         except ValidationError as e:
             return Response({"message": str(e)}, status=status.HTTP_400_BAD_REQUEST)
         except ConflictError as e:
             return Response({"message": str(e)}, status=status.HTTP_409_CONFLICT)
-        except Exception as e:
-            return Response({"message": "An unexpected error occurred."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except Exception:
+            return Response(
+                {"message": "An unexpected error occurred."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
 
     def get_event(self, event_id):
         try:
@@ -99,18 +118,23 @@ class EventAPIView(
         if event.seats_left is None:
             raise ValidationError("Registration hasn't started yet.")
         if event.seats_left < 1:
-            raise ValidationError("Unfortunately, there are no more seats left for the event.")
-
+            raise ValidationError(
+                "Unfortunately, there are no more seats left for the event."
+            )
 
     def _check_existing_registration(self, email, event_id):
         if EventRegistration.objects.filter(email=email, event=event_id).exists():
-            raise ConflictError("We get it, you're excited. But you've already secured your ticket!")
+            raise ConflictError(
+                "We get it, you're excited. But you've already secured your ticket!"
+            )
 
     def _send_confirmation_email(self, email, event_id):
         registration_confirmation_email_task.delay(email, event_id)
 
+
 class ValidationError(Exception):
     pass
+
 
 class ConflictError(Exception):
     pass

--- a/frontend/src/utils/apiUrl.ts
+++ b/frontend/src/utils/apiUrl.ts
@@ -1,7 +1,7 @@
 export function getApiUrl() {
     if (typeof window === 'undefined') {
       // Server-side
-      return process.env.API_URL;
+      return process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL;
     } else {
       // Client-side
       return process.env.NEXT_PUBLIC_API_URL;


### PR DESCRIPTION
Added filter to only allow community partners
which were created before the event while fetching partners in `EventApiView.retrieve` method


# Closes #212 

### Changes
- added filter in `EventApiView.retrieve` method
- removed unused imports which were throwing lint errors

### Type of change
- [x] Bug fix
- [ ] Feature update
- [ ] Breaking change
- [ ] Documentation update

### How has this been tested?
- Manually 

### Author Checklist
- [x] Code has been commented, particularly in hard-to-understand areas 
- [x] Changes generate no new warnings
- [ ] Vital changes have been captured in unit and/or integration tests
- [x] New and existing unit tests pass locally with my changes
- [ ] Documentation has been extended, if necessary
- [x] Merging to `main` from `fork:issue_212`
