### PR TITLE
Fixes #230: Server crash due to lack of background task for send_mass_email at event registration

### DIFF
--- a/backend/djangoindia/bg_tasks/event_registration.py
+++ b/backend/djangoindia/bg_tasks/event_registration.py
@@ -56,7 +56,7 @@ def registration_confirmation_email_task(email, event_id):
 
 
 @shared_task(bind=True, max_retries=3)
-def send_mass_email_task(self, emails, **kwargs):
+def send_mass_mail_task(self, emails, **kwargs):
     """
     Converts django.core.mail.send_mass_email into a background task.
 

--- a/backend/djangoindia/db/admin.py
+++ b/backend/djangoindia/db/admin.py
@@ -11,7 +11,7 @@ from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import path
 
-from djangoindia.bg_tasks.event_registration import send_mass_email_task
+from djangoindia.bg_tasks.event_registration import send_mass_mail_task
 from djangoindia.db.models.communication import ContactUs, Subscriber
 from djangoindia.db.models.event import Event, EventRegistration
 from djangoindia.db.models.partner_and_sponsor import (
@@ -124,7 +124,7 @@ class EventRegistrationAdmin(ImportExportModelAdmin):
                         recipient_email = registration.email
                         emails.append((subject, message, from_email, [recipient_email]))
 
-                    send_mass_email_task(emails, fail_silently=False)
+                    send_mass_mail_task(emails, fail_silently=False)
                     messages.success(
                         request, f"{len(emails)} emails sent successfully."
                     )

--- a/backend/djangoindia/db/admin.py
+++ b/backend/djangoindia/db/admin.py
@@ -1,5 +1,3 @@
-from bg_tasks.event_registration import send_mass_email_task
-
 # from django.conf import settings
 from import_export import fields, resources
 from import_export.admin import ImportExportModelAdmin
@@ -13,6 +11,7 @@ from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import path
 
+from djangoindia.bg_tasks.event_registration import send_mass_email_task
 from djangoindia.db.models.communication import ContactUs, Subscriber
 from djangoindia.db.models.event import Event, EventRegistration
 from djangoindia.db.models.partner_and_sponsor import (

--- a/backend/djangoindia/db/admin.py
+++ b/backend/djangoindia/db/admin.py
@@ -1,3 +1,5 @@
+from bg_tasks.event_registration import send_mass_email_task
+
 # from django.conf import settings
 from import_export import fields, resources
 from import_export.admin import ImportExportModelAdmin
@@ -5,7 +7,6 @@ from import_export.widgets import ForeignKeyWidget
 
 from django.conf import settings
 from django.contrib import admin, messages
-from django.core.mail import send_mass_mail
 from django.db import transaction
 from django.db.models import Count, F
 from django.shortcuts import redirect
@@ -124,7 +125,7 @@ class EventRegistrationAdmin(ImportExportModelAdmin):
                         recipient_email = registration.email
                         emails.append((subject, message, from_email, [recipient_email]))
 
-                    send_mass_mail(emails, fail_silently=False)
+                    send_mass_email_task(emails, fail_silently=False)
                     messages.success(
                         request, f"{len(emails)} emails sent successfully."
                     )


### PR DESCRIPTION
# Closes #230 
converts `django.core.mail.send_mass_mail` function used in `EventRegistration` admin into a background task wrapper in order to avoid crashing at nginx. 

### Changes
new shared task `send_mass_mail_task` at `bg_tasks.event_registration`
make use of `send_mass_mail_task` in `EventRegistrationAdmin`
- <ONE>
- <TWO>

### Type of change
- [x] Bug fix
- [ ] Feature update
- [ ] Breaking change
- [ ] Documentation update

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- Needs testing

### How has this been tested?
<!---[Describe the tests that you ran to verify your changes]-->
- Not tested yet

### Author Checklist
- [x] Code has been commented, particularly in hard-to-understand areas 
- [ ] Changes generate no new warnings
- [ ] Vital changes have been captured in unit and/or integration tests
- [ ] New and existing unit tests pass locally with my changes
- [ ] Documentation has been extended, if necessary
- [ ] Merging to `main` from `fork:branchname`

