### PR TITLE
Fixed #207 -- Add lint check on pre-commit for front end

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
             .*\.js
           )$
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.3.2
+    rev: v2.3.2 # Use the version you need
     hooks:
       - id: prettier
         additional_dependencies: [prettier@2.3.2]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,40 +1,42 @@
 exclude: ^docs/
 
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
-  hooks:
-  - id: check-yaml
-  - id: check-case-conflict
-  - id: check-json
-  - id: check-merge-conflict
-  - id: check-symlinks
-  - id: check-toml
-  - id: end-of-file-fixer
-    exclude: ^(frontend/|.*\.js$)
-  - id: requirements-txt-fixer
-  - id: detect-private-key
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.5
-  hooks:
-    - id: ruff
-      args: [
-        --fix,
-        --select=I, # only run imports sorting
-        --exit-non-zero-on-fix,
-      ]
-    - id: ruff
-      args: [
-        --fix,
-        --exit-non-zero-on-fix,
-      ]
-    - id: ruff-format
-- repo: https://github.com/Yelp/detect-secrets
-  rev: v1.5.0
-  hooks:
-  - id: detect-secrets
-    exclude: |
-        (?x)^(
-          package.lock.json|
-          .*\.js
-        )$
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-yaml
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-toml
+      - id: end-of-file-fixer
+        exclude: ^(frontend/|.*\.js$)
+      - id: requirements-txt-fixer
+      - id: detect-private-key
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.5
+    hooks:
+      - id: ruff
+        args: [
+            --fix,
+            --select=I, # only run imports sorting
+            --exit-non-zero-on-fix,
+          ]
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        exclude: |
+          (?x)^(
+            package.lock.json|
+            .*\.js
+          )$
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.3.2 # Use the version you need
+    hooks:
+      - id: prettier
+        additional_dependencies: [prettier@2.3.2]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
             .*\.js
           )$
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.3.2 # Use the version you need
+    rev: v2.3.2
     hooks:
       - id: prettier
         additional_dependencies: [prettier@2.3.2]


### PR DESCRIPTION
This PR updates the .pre-commit-config.yaml file to include Prettier for linting front-end code.

closes #207 