### PR TITLE
Fixed event ordering issue

### DIFF
--- a/backend/djangoindia/api/views/base.py
+++ b/backend/djangoindia/api/views/base.py
@@ -47,9 +47,7 @@ class BaseViewSet(TimezoneMixin, ModelViewSet):
 
     def get_queryset(self):
         try:
-            if hasattr(self, "queryset") and self.queryset is not None:
-                return self.queryset
-            return self.model.objects.all()
+            return self.queryset or self.model.objects.all()
         except Exception as e:
             raise APIException("Please check the view", status.HTTP_400_BAD_REQUEST)
 

--- a/backend/djangoindia/api/views/base.py
+++ b/backend/djangoindia/api/views/base.py
@@ -47,6 +47,8 @@ class BaseViewSet(TimezoneMixin, ModelViewSet):
 
     def get_queryset(self):
         try:
+            if hasattr(self, "queryset") and self.queryset is not None:
+                return self.queryset
             return self.model.objects.all()
         except Exception as e:
             raise APIException("Please check the view", status.HTTP_400_BAD_REQUEST)

--- a/backend/djangoindia/api/views/event.py
+++ b/backend/djangoindia/api/views/event.py
@@ -106,7 +106,7 @@ class EventAPIView(BaseViewSet):
         return EventLiteSerializer
 
     def list(self, request, *args, **kwargs):
-        queryset = self.get_queryset()
+        queryset = Event.objects.all().order_by("start_date")
         all_community_partners = CommunityPartner.objects.all()
         serializer = self.get_serializer(
             queryset,

--- a/backend/djangoindia/api/views/event.py
+++ b/backend/djangoindia/api/views/event.py
@@ -106,7 +106,7 @@ class EventAPIView(BaseViewSet):
         return EventLiteSerializer
 
     def list(self, request, *args, **kwargs):
-        queryset = Event.objects.all().order_by("start_date")
+        queryset = self.get_queryset()
         all_community_partners = CommunityPartner.objects.all()
         serializer = self.get_serializer(
             queryset,


### PR DESCRIPTION
# Closes #309 

This PR improves the event listing API by filtering out past events and ordering upcoming events by start date in ascending order. 



