### PR TITLE
Fix zoom issue on sign-up form

### DIFF
--- a/frontend/src/containers/Signup/Signup.tsx
+++ b/frontend/src/containers/Signup/Signup.tsx
@@ -89,16 +89,16 @@ const SignupForm = () => {
   };
 
   return (
-    <section className='relative flex size-full overflow-hidden'>
+    <section className='relative flex min-h-screen w-full overflow-auto'>
       <Link
         href='/home'
-        className='group pointer-events-auto absolute right-4 top-4 z-50 w-fit rounded-full p-3 transition-all duration-300 hover:bg-blue-100 hover:shadow-xl sm:left-4'
+        className='group pointer-events-auto fixed top-4 left-4 z-50 w-fit rounded-full p-3 transition-all duration-300 hover:bg-blue-100 hover:shadow-xl'
       >
         <FaHome className='text-2xl text-[#06038D] transition-transform duration-300 group-hover:scale-110' />
       </Link>
       <div className='z-10 flex flex-1 items-center justify-center'>
         <motion.div
-          className='w-4/5 sm:w-3/5'
+          className='w-full max-w-md px-6 sm:w-3/5 min-h-full pt-12'
           initial={{ x: -100 }}
           animate={{ x: 0 }}
           transition={{
@@ -254,7 +254,7 @@ const SignupForm = () => {
         </motion.div>
       </div>
       <motion.div
-        className='absolute bottom-1/3 right-1/4 z-0 size-[1400px] sm:right-1/2'
+        className='fixed bottom-10 right-10 z-0 w-[800px] sm:right-1/3'
         initial={{ x: -100, y: -100 }}
         animate={{ x: -20, y: 0 }}
         transition={{


### PR DESCRIPTION
# Closes #<CORRESPONDING ISSUE NUMBER>
#319 has been resolved.

### Changes
- min-h-screen: Ensures content takes at least full height.
- overflow-auto: Allows scrolling if the content exceeds the viewport.
- min-h-full: Ensures content is not cut off at different zoom levels.
- pt-12 → Adds extra padding at the top to ensure the text remains visible.

### Type of change
- [x] Bug fix
- [ ] Feature update
- [ ] Breaking change
- [ ] Documentation update

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Demo
<!--- Provide an easily accessible demonstration of the changes, if applicable (preferably in png/gif format) -->
- <ONE>
- <TWO>

### How has this been tested?
- I did manual test on my local and checked the signup form. 

### Author Checklist
- [ ] Code has been commented, particularly in hard-to-understand areas 
- [ ] Changes generate no new warnings
- [ ] Vital changes have been captured in unit and/or integration tests
- [ ] New and existing unit tests pass locally with my changes
- [ ] Documentation has been extended, if necessary
- [ ] Merging to `main` from `fork:branchname`

### Additional context 
<!--- [Add any other context about the PR here] -->
- <ONE>
- <TWO>
