### PR TITLE
Add a button to hide/unhide password fields

### DIFF
--- a/frontend/src/containers/Signup/Signup.tsx
+++ b/frontend/src/containers/Signup/Signup.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 
 import { yupResolver } from '@hookform/resolvers/yup';
 import { motion } from 'motion/react';
@@ -10,7 +10,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 import { enqueueSnackbar } from 'notistack';
 import { type SubmitHandler, useForm } from 'react-hook-form';
-import { FaGoogle, FaHome } from 'react-icons/fa';
+import { FaGoogle, FaHome , FaEye, FaEyeSlash } from 'react-icons/fa';
 
 import { Button, Input, Label } from '@/components';
 import { API_ENDPOINTS, SIGNUP_FORM_SCHEMA } from '@/constants';
@@ -22,6 +22,8 @@ const SignupForm = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirect = searchParams.get('redirect') || undefined;
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const {
     register,
@@ -63,6 +65,8 @@ const SignupForm = () => {
     }
   };
 
+  const togglePasswordVisibility = () => setShowPassword((prev) => !prev);
+  const toggleConfirmPasswordVisibility = () => setShowConfirmPassword((prev) => !prev);
   const onSubmit: SubmitHandler<SignupFormType> = async (data) => {
     const res = await fetchData<{ access_token: string }>(
       API_ENDPOINTS.signup,
@@ -186,13 +190,22 @@ const SignupForm = () => {
               >
                 New password
               </Label>
+              <div className='relative'>
               <Input
                 {...register('newPassword', { required: true })}
-                type='password'
+                type={showPassword ? 'text' : 'password'}
                 id='newPassword'
                 placeholder='Enter new password'
                 className={`${errors.newPassword ? 'text-red-500 !outline-red-500' : ''}`}
               />
+              <button 
+              type='button'
+              onClick={togglePasswordVisibility}
+              className='absolute inset-y-0 right-3 flex items-center text-gray-600'
+              >
+                {showPassword ? <FaEyeSlash /> : <FaEye />}
+                </button>
+                </div>
               <p className='h-[20px] text-sm text-red-500'>
                 {errors.newPassword?.message ?? ' '}
               </p>
@@ -204,13 +217,22 @@ const SignupForm = () => {
               >
                 Confirm Password
               </Label>
+              <div className='relative'>
               <Input
                 {...register('confirmPassword', { required: true })}
-                type='password'
+                type={showConfirmPassword ? 'text' : 'password'}
                 id='confirmPassword'
                 placeholder='Confirm password'
                 className={`${errors.confirmPassword ? 'text-red-500 !outline-red-500' : ''}`}
               />
+              <button
+              type='button'
+              onClick={toggleConfirmPasswordVisibility}
+              className='absolute inset-y-0 right-3 flex items-center text-gray-600'
+              >
+                {showConfirmPassword ? <FaEyeSlash /> : <FaEye />}
+                </button>
+                </div>
               <p className='h-[20px] text-sm text-red-500'>
                 {errors.confirmPassword?.message ?? ' '}
               </p>

--- a/frontend/src/containers/Signup/Signup.tsx
+++ b/frontend/src/containers/Signup/Signup.tsx
@@ -89,16 +89,16 @@ const SignupForm = () => {
   };
 
   return (
-    <section className='relative flex size-full overflow-hidden'>
+    <section className='relative flex min-h-screen w-full overflow-auto'>
       <Link
         href='/home'
-        className='group pointer-events-auto absolute right-4 top-4 z-50 w-fit rounded-full p-3 transition-all duration-300 hover:bg-blue-100 hover:shadow-xl sm:left-4'
+        className='group pointer-events-auto fixed top-4 left-4 z-50 w-fit rounded-full p-3 transition-all duration-300 hover:bg-blue-100 hover:shadow-xl'
       >
         <FaHome className='text-2xl text-[#06038D] transition-transform duration-300 group-hover:scale-110' />
       </Link>
       <div className='z-10 flex flex-1 items-center justify-center'>
         <motion.div
-          className='w-4/5 sm:w-3/5'
+          className='w-full max-w-md px-6 sm:w-3/5 min-h-full pt-12'
           initial={{ x: -100 }}
           animate={{ x: 0 }}
           transition={{
@@ -254,7 +254,7 @@ const SignupForm = () => {
         </motion.div>
       </div>
       <motion.div
-        className='absolute bottom-1/3 right-1/4 z-0 size-[1400px] sm:right-1/2'
+        className='fixed bottom-10 right-10 z-0 w-[800px] sm:right-1/3'
         initial={{ x: -100, y: -100 }}
         animate={{ x: -20, y: 0 }}
         transition={{

--- a/frontend/src/containers/Signup/Signup.tsx
+++ b/frontend/src/containers/Signup/Signup.tsx
@@ -93,16 +93,16 @@ const SignupForm = () => {
   };
 
   return (
-    <section className='relative flex min-h-screen w-full overflow-auto'>
+    <section className='relative flex size-full overflow-hidden'>
       <Link
         href='/home'
-        className='group pointer-events-auto fixed top-4 left-4 z-50 w-fit rounded-full p-3 transition-all duration-300 hover:bg-blue-100 hover:shadow-xl'
+        className='group pointer-events-auto absolute right-4 top-4 z-50 w-fit rounded-full p-3 transition-all duration-300 hover:bg-blue-100 hover:shadow-xl sm:left-4'
       >
         <FaHome className='text-2xl text-[#06038D] transition-transform duration-300 group-hover:scale-110' />
       </Link>
       <div className='z-10 flex flex-1 items-center justify-center'>
         <motion.div
-          className='w-full max-w-md px-6 sm:w-3/5 min-h-full pt-12'
+          className='w-4/5 sm:w-3/5'
           initial={{ x: -100 }}
           animate={{ x: 0 }}
           transition={{
@@ -117,7 +117,7 @@ const SignupForm = () => {
               Login here!
             </Link>
           </div>
-          <h3 className='text-5xl font-black text-[#06038D]'>
+          <h3 className='text-4xl font-black text-[#06038D]'>
             Create an account
           </h3>
           <span className='my-4 inline-block font-semibold text-gray-600'>
@@ -276,7 +276,7 @@ const SignupForm = () => {
         </motion.div>
       </div>
       <motion.div
-        className='fixed bottom-10 right-10 z-0 w-[800px] sm:right-1/3'
+        className='absolute bottom-1/3 right-1/4 z-0 size-[1400px] sm:right-1/2'
         initial={{ x: -100, y: -100 }}
         animate={{ x: -20, y: 0 }}
         transition={{


### PR DESCRIPTION
# Closes #320 
A button to hide/unhide password fields has been added. 
#320 has been resolved. 

### Changes
- An eye icon has been added inside the button.
- A JavaScript function has been added to switch the input field between "password" and "text" when clicked.
- Onclick has been added to call a JavaScript function that toggles password visibility.


### Type of change
- [ ] Bug fix
- [x] Feature update
- [ ] Breaking change
- [ ] Documentation update

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Demo
<!--- Provide an easily accessible demonstration of the changes, if applicable (preferably in png/gif format) -->

https://github.com/user-attachments/assets/f259d44f-b404-448b-ba58-15b9511ead69



### How has this been tested?
<!---[Describe the tests that you ran to verify your changes]-->
- A manual test has been done

### Author Checklist
- [ ] Code has been commented, particularly in hard-to-understand areas 
- [ ] Changes generate no new warnings
- [ ] Vital changes have been captured in unit and/or integration tests
- [ ] New and existing unit tests pass locally with my changes
- [ ] Documentation has been extended, if necessary
- [ ] Merging to `main` from `fork:branchname`

### Additional context 
<!--- [Add any other context about the PR here] -->
- <ONE>
- <TWO>
