### PR TITLE
Fixed #357 - Password hashing when changed manually in admin

### DIFF
--- a/backend/djangoindia/db/models/user.py
+++ b/backend/djangoindia/db/models/user.py
@@ -18,7 +18,7 @@ from django.contrib.auth.models import (
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-
+from django.contrib.auth.hashers import make_password
 from .base import BaseModel
 
 
@@ -114,6 +114,9 @@ class User(AbstractBaseUser, PermissionsMixin):
 
     def save(self, *args, **kwargs):
         self.email = self.email.lower().strip()
+
+        if not self.password.startswith('pbkdf2_sha256'):
+            self.password = make_password(self.password)
 
         if self.is_superuser:
             self.is_staff = True


### PR DESCRIPTION
# Closes #357 
Now password will be hashed when modified in admin

### Changes
- Added hash function in users model

### Type of change
- [x] Bug fix
- [ ] Feature update
- [ ] Breaking change
- [ ] Documentation update

### How has this been tested?
- After changing password, a login attempt had been done.
- 
### Author Checklist
- [x] Code has been commented, particularly in hard-to-understand areas 
- [x] Changes generate no new warnings
- [ ] Vital changes have been captured in unit and/or integration tests
- [ ] New and existing unit tests pass locally with my changes
- [ ] Documentation has been extended, if necessary
- [x] Merging to `main` from `fork:branchname`